### PR TITLE
Add void trader to event probability engine

### DIFF
--- a/backtest/quantum_backtest.py
+++ b/backtest/quantum_backtest.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+def simulate_branch_entropy(timeline_seed):
+    np.random.seed(timeline_seed)
+    return {
+        event: np.random.dirichlet(np.ones(3))[0]
+        for event in self.branch_data
+    }
+
+def run_quantum_backtest():
+    timelines = generate_branching_simulations(depth=9)
+    results = []
+    for path in timelines:
+        outcome = simulate_path(path)
+        results.append(outcome)
+    return aggregate_results(results)

--- a/ultra_modules/multiversal_risk_split.py
+++ b/ultra_modules/multiversal_risk_split.py
@@ -3,14 +3,37 @@ from ultra_modules.event_probability_engine import EventProbabilityEngine
 class MultiversalRiskSplit:
     def __init__(self, branch_data, entropy_baseline):
         self.engine = EventProbabilityEngine(branch_data, entropy_baseline)
+        self.capital = 0
 
     def calculate_split(self, capital):
-        probabilities = self.engine.get_event_probabilities()
+        self.capital = capital
+        results = []
+        for t in range(9):  # 9-timeline simulation
+            alt_probs = self._simulate_branch_entropy(t)
+            alloc = self._simulate_allocation(alt_probs)
+            results.append(alloc)
+        return self._aggregate_timelines(results)
+
+    def _simulate_branch_entropy(self, seed):
+        np.random.seed(seed)
+        return {
+            event: np.random.dirichlet(np.ones(3))[0]
+            for event in self.engine.branch_data
+        }
+
+    def _simulate_allocation(self, alt_probs):
         risk_alloc = {}
-        for event, prob in probabilities.items():
+        for event, prob in alt_probs.items():
             weight = self._calculate_dimensional_weight(event)
-            risk_alloc[event] = round(capital * prob * weight, 2)
+            risk_alloc[event] = round(self.capital * prob * weight, 2)
         return risk_alloc
+
+    def _aggregate_timelines(self, results):
+        final_alloc = {}
+        for alloc in results:
+            for event, val in alloc.items():
+                final_alloc[event] = final_alloc.get(event, 0) + val / len(results)
+        return final_alloc
 
     def _calculate_dimensional_weight(self, event):
         return 1.0 if "critical" in event.lower() else 0.618


### PR DESCRIPTION
- Added `_scan_liquidity_void` to `event_probability_engine.py` for detecting liquidity voids  
- Integrated void signal into `get_event_probabilities`  
- Added `_simulate_branch_entropy`, `_simulate_allocation`, and `_aggregate_timelines` to `multiversal_risk_split.py`  
- Updated `calculate_split` to incorporate entropy simulation  
- Introduced `simulate_branch_entropy` and `run_quantum_backtest` methods in `quantum_backtest.py`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Lapommeray/quant-trading-system/pull/10?shareId=179ff31f-4463-410b-b291-23c415af7e53).